### PR TITLE
Include path in hash of file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ module.exports = function (folder, hash, log, disable) {
         if (doLog) doLog(err, false)
         return cb(err)
       }
-      var fileHash = createHash(fileData)
+      var fileHash = createHash(file + fileData)
       var cacheStart = hrtime()
       cacheFile = path.join(cachePrefix + '_' + fileHash + '.json')
       return readFile(cacheFile, 'utf8', function (_err, rawCacheData) {


### PR DESCRIPTION
#3 
This uses the path of the file in addition to the content of the file to ensure that each input file gets cached at a unique location.