### PR TITLE
Using wx to prevent concurrent writes to the cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,7 +201,7 @@ module.exports = function (folder, hash, log, disable) {
             if (err) {
               return cb(err)
             }
-            writeFile(cacheFile, JSON.stringify(data, null, 2), function () {
+            writeFile(cacheFile, JSON.stringify(data, null, 2), {flag: 'wx'}, function () {
               // Don't wait, don't care
             })
             cb(null, data)

--- a/test/cache.js
+++ b/test/cache.js
@@ -27,7 +27,16 @@ function processFile (source, cb) {
   })
 }
 
+function wait (duration) {
+  return function () {
+    return new Promise(function (resolve) {
+      setTimeout(resolve, duration)
+    })
+  }
+}
+
 const fileA = createFile('a.js', 'var a = 1')
+const fileB = createFile('b.js', 'var b = 1')
 
 test('cache one file', function (t) {
   var persist = Promise.promisify(brfypersist(tmpTarget, {}))
@@ -41,5 +50,31 @@ test('cache one file', function (t) {
           t.same(resultA.deps, ['foo', 'bar'])
           t.same(resultA.pkg.name, 'baz')
         })
+    })
+})
+
+test('parallel caching only writes once', function (t) {
+  var persist = Promise.promisify(brfypersist(tmpTarget, {}))
+  var _firstFallback
+  var fallback = function (source, cb) {
+    if (!_firstFallback) {
+      _firstFallback = cb
+      return
+    }
+    setImmediate(function () {
+      // Triggering a writing of the cache in the same tick
+      _firstFallback(null, {first: true})
+      cb(null, {first: false})
+    })
+  }
+  return Promise.all([
+    persist(fileB, null, null, fallback),
+    persist(fileB, null, null, fallback)
+  ])
+    .then(wait(100)) // The cache file may not have been written yet
+    .then(function (results) {
+      const cacheFilePath = path.join(tmpTarget, 'bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f_d63c02b75372e4e64783538bff55c8f18ce4cf0c.json')
+      t.ok(fs.existsSync(cacheFilePath), 'tmp created')
+      t.same(JSON.parse(fs.readFileSync(cacheFilePath, 'utf-8')), {first: true}, 'Only the first write succeeded')
     })
 })


### PR DESCRIPTION
@loklaan  kindly provided #5 as an attempt to prevent to deal with the issue presented in #3. When reviewing it and writing a test I thought that using `wx` as a file mode might be more efficient - as it works even though not the same node instance is trying to access the same cache - and results in less lines of code. 